### PR TITLE
Fix current time in system prompt

### DIFF
--- a/src/systemPrompt.ts
+++ b/src/systemPrompt.ts
@@ -3,7 +3,7 @@ const getCurrentTime = () => new Date().toLocaleString();
 export const systemPrompt = `
 You are a helpful AI assistant that can use tools to answer user questions. Follow these instructions:
 
-- Current time: ${getCurrentTime}
+ - Current time: ${getCurrentTime()}
 - Don't use celebrity names in image generation prompts, instead replace them with generic character traits.
 - Always be polite and respectful.
 - Provide accurate and concise information.


### PR DESCRIPTION
## Summary
- fix bug in system prompt time interpolation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ff2839ca4832b9844359d44413496